### PR TITLE
Add Reset Retreat event and update Sound Immersion details

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,7 +669,7 @@
     </div>
     <div class="events-grid">
       <div class="event-card">
-        <img src="https://github.com/user-attachments/assets/f71661c6-9da1-4f7d-8be9-af489a76b5f8" alt="The Reset Retreat poster" class="event-image">
+        <img src="https://github.com/user-attachments/assets/bcceb816-7e76-4e00-b3c5-e099c60c2e56" alt="The Reset Retreat poster" class="event-image">
         <div class="event-content">
           <h3 class="event-title">The Reset Retreat</h3>
           <p class="event-host">Spring into Summer: A morning experience curated by Dragonfly Method</p>

--- a/index.html
+++ b/index.html
@@ -669,13 +669,24 @@
     </div>
     <div class="events-grid">
       <div class="event-card">
+        <img src="https://github.com/user-attachments/assets/f71661c6-9da1-4f7d-8be9-af489a76b5f8" alt="The Reset Retreat poster" class="event-image">
+        <div class="event-content">
+          <h3 class="event-title">The Reset Retreat</h3>
+          <p class="event-host">Spring into Summer: A morning experience curated by Dragonfly Method</p>
+          <p class="event-location">Yoga · Breathwork · Sound Bath · Reiki · Social &amp; Light Brunch</p>
+          <p class="event-location">Montclair Country Club, 16500 Edgewood Drive, Montclair, VA 22025</p>
+          <p class="event-datetime">Saturday, May 23 from 9 am to 12 pm ET</p>
+          <a href="https://www.dragonfly-method.com/offerings/the-reset-retreat" class="event-link" target="_blank" rel="noopener">Attend Event</a>
+        </div>
+      </div>
+      <div class="event-card">
         <img src="https://images.unsplash.com/photo-1749642955698-ebe5e4579034?q=80&w=1074&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="Sound healing session" class="event-image">
         <div class="event-content">
-          <h3 class="event-title">Sound Immersion for Rest & Renewal: Stillness, Serenity & Grounded</h3>
+          <h3 class="event-title">Sound Immersion for Rest &amp; Renewal: stillness, serenity &amp; grounded</h3>
           <p class="event-host">Bear River Massage and Yoga</p>
           <p class="event-location">29 Banks Ford Pkwy suite 109, Fredericksburg, VA</p>
-          <p class="event-datetime">Sunday, Mar 15 from 6 pm to 7 pm ET</p>
-          <a href="https://www.eventbrite.com/e/sound-immersion-for-rest-renewal-stillness-serenity-grounded-tickets-1983359205775?aff=ebdsoporgprofile" class="event-link" target="_blank" rel="noopener">Attend Event</a>
+          <p class="event-datetime">Sunday, June 7 from 6 pm to 7 pm ET</p>
+          <a href="https://www.eventbrite.com/e/sound-immersion-for-rest-renewal-tickets-1985239563977?sg=f8fa5f5da78e9d0b97cf6a3860348a9b9db2c731570a33ef38890ac1531a57f0fe8252b1e1db9844074d3c32f75c6a881022b61561b57d2c0587a92c01a1cc82b8131c2c321ba3e2954696b466&aff=ebdsshios" class="event-link" target="_blank" rel="noopener">Attend Event</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Adds new event card for The Reset Retreat (Dragonfly Method, Montclair Country Club, May 23)
- Updates Sound Immersion event: new date (June 7), updated title casing, and new Eventbrite link

Closes #20
Closes #21