### PR TITLE
Add Petals & Frequency event and Past Events section

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,6 +698,16 @@
           <a href="https://www.eventbrite.com/e/petals-frequency-a-summer-solstice-retreat-tickets-1989432374787" class="event-link" target="_blank" rel="noopener">Attend Event</a>
         </div>
       </div>
+      <div class="event-card">
+        <img src="https://images.unsplash.com/photo-1749642955698-ebe5e4579034?q=80&w=1074&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="Sound healing session" class="event-image">
+        <div class="event-content">
+          <h3 class="event-title">Sound Immersion for Rest &amp; Renewal: stillness, serenity &amp; grounded</h3>
+          <p class="event-host">Bear River Massage and Yoga</p>
+          <p class="event-location">29 Banks Ford Pkwy suite 109, Fredericksburg, VA</p>
+          <p class="event-datetime">Sunday, June 7 from 6 pm to 7 pm ET</p>
+          <a href="https://www.eventbrite.com/e/sound-immersion-for-rest-renewal-tickets-1985239563977?sg=f8fa5f5da78e9d0b97cf6a3860348a9b9db2c731570a33ef38890ac1531a57f0fe8252b1e1db9844074d3c32f75c6a881022b61561b57d2c0587a92c01a1cc82b8131c2c321ba3e2954696b466&aff=ebdsshios" class="event-link" target="_blank" rel="noopener">Attend Event</a>
+        </div>
+      </div>
     </div>
     <h3 class="past-events-heading">Past Events</h3>
     <div class="events-grid">
@@ -718,7 +728,7 @@
           <h3 class="event-title">Sound Immersion for Rest &amp; Renewal: stillness, serenity &amp; grounded</h3>
           <p class="event-host">Bear River Massage and Yoga</p>
           <p class="event-location">29 Banks Ford Pkwy suite 109, Fredericksburg, VA</p>
-          <p class="event-datetime">Sunday, June 7 from 6 pm to 7 pm ET</p>
+          <p class="event-datetime">Sunday, Mar 15 from 6 pm to 7 pm ET</p>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -226,6 +226,17 @@
       animation-delay: 0.4s;
     }
 
+    .past-events-heading {
+      font-family: 'Outfit', sans-serif;
+      font-size: clamp(1.25rem, 3vw, 1.75rem);
+      font-weight: 300;
+      letter-spacing: 0.05em;
+      color: var(--deep-clay);
+      max-width: 1200px;
+      margin: 4rem auto 2rem;
+      padding: 0;
+    }
+
     .event-card:hover {
       transform: translateY(-8px);
       box-shadow: 0 12px 24px rgba(139, 111, 92, 0.15);
@@ -676,6 +687,21 @@
     </div>
     <div class="events-grid">
       <div class="event-card">
+        <img src="https://github.com/user-attachments/assets/fb17b541-43be-4021-a5eb-a5f7cad04666" alt="Petals & Frequency: A Summer Solstice Retreat poster" class="event-image">
+        <div class="event-content">
+          <h3 class="event-title">Petals &amp; Frequency Collective: A Summer Solstice Retreat</h3>
+          <p class="event-location">Curated by Cosmic Connections</p>
+          <p class="event-location">An intimate full-day retreat experience blending astrology, sound healing, breathwork, meditation, yoga, acupuncture, nourishment, and intentional rest in a serene spa-like setting created to support softness, clarity, grounding, expansion, and deep restoration.</p>
+          <p class="event-host">Elysium Healing Oasis</p>
+          <p class="event-location">6634 South Kings Highway, Alexandria, VA 22306</p>
+          <p class="event-datetime">Saturday, June 13 from 10 am to 4 pm ET</p>
+          <a href="https://www.eventbrite.com/e/petals-frequency-a-summer-solstice-retreat-tickets-1989432374787" class="event-link" target="_blank" rel="noopener">Attend Event</a>
+        </div>
+      </div>
+    </div>
+    <h3 class="past-events-heading">Past Events</h3>
+    <div class="events-grid">
+      <div class="event-card">
         <img src="https://github.com/user-attachments/assets/4cb76323-4bf3-424d-9305-2b740b4eac3d" alt="The Reset Retreat poster" class="event-image">
         <div class="event-content">
           <h3 class="event-title">The Reset Retreat</h3>
@@ -684,7 +710,6 @@
           <p class="event-host">Montclair Country Club</p>
           <p class="event-location">16500 Edgewood Drive, Montclair, VA 22025</p>
           <p class="event-datetime">Saturday, May 23 from 9 am to 12 pm ET</p>
-          <a href="https://www.dragonfly-method.com/offerings/the-reset-retreat" class="event-link" target="_blank" rel="noopener">Attend Event</a>
         </div>
       </div>
       <div class="event-card">
@@ -694,7 +719,6 @@
           <p class="event-host">Bear River Massage and Yoga</p>
           <p class="event-location">29 Banks Ford Pkwy suite 109, Fredericksburg, VA</p>
           <p class="event-datetime">Sunday, June 7 from 6 pm to 7 pm ET</p>
-          <a href="https://www.eventbrite.com/e/sound-immersion-for-rest-renewal-tickets-1985239563977?sg=f8fa5f5da78e9d0b97cf6a3860348a9b9db2c731570a33ef38890ac1531a57f0fe8252b1e1db9844074d3c32f75c6a881022b61561b57d2c0587a92c01a1cc82b8131c2c321ba3e2954696b466&aff=ebdsshios" class="event-link" target="_blank" rel="noopener">Attend Event</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Adds new upcoming event: **Petals & Frequency Collective: A Summer Solstice Retreat** (June 13, curated by Cosmic Connections at Elysium Healing Oasis) with Eventbrite link and event image
- Adds **Past Events** subheading below the upcoming events grid
- Moves The Reset Retreat and Sound Immersion events under Past Events, removing their Attend Event buttons

Closes #25
Closes #26

## Test plan

- [ ] Verify new Petals & Frequency event card appears in the Upcoming Events section with correct image, details, and Attend Event link
- [ ] Verify Elysium Healing Oasis venue name appears in pink (terracotta) color
- [ ] Verify "Past Events" subheading appears below the upcoming event
- [ ] Verify The Reset Retreat and Sound Immersion cards appear under Past Events without Attend Event buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)