### PR TITLE
Move Petals & Frequency event to Past Events

### DIFF
--- a/index.html
+++ b/index.html
@@ -687,18 +687,6 @@
     </div>
     <div class="events-grid">
       <div class="event-card">
-        <img src="https://github.com/user-attachments/assets/fb17b541-43be-4021-a5eb-a5f7cad04666" alt="Petals & Frequency: A Summer Solstice Retreat poster" class="event-image">
-        <div class="event-content">
-          <h3 class="event-title">Petals &amp; Frequency Collective: A Summer Solstice Retreat</h3>
-          <p class="event-location">Curated by Cosmic Connections</p>
-          <p class="event-location">An intimate full-day retreat experience blending astrology, sound healing, breathwork, meditation, yoga, acupuncture, nourishment, and intentional rest in a serene spa-like setting created to support softness, clarity, grounding, expansion, and deep restoration.</p>
-          <p class="event-host">Elysium Healing Oasis</p>
-          <p class="event-location">6634 South Kings Highway, Alexandria, VA 22306</p>
-          <p class="event-datetime">Saturday, June 13 from 10 am to 4 pm ET</p>
-          <a href="https://www.eventbrite.com/e/petals-frequency-a-summer-solstice-retreat-tickets-1989432374787" class="event-link" target="_blank" rel="noopener">Attend Event</a>
-        </div>
-      </div>
-      <div class="event-card">
         <img src="https://images.unsplash.com/photo-1749642955698-ebe5e4579034?q=80&w=1074&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="Sound healing session" class="event-image">
         <div class="event-content">
           <h3 class="event-title">Sound Immersion for Rest &amp; Renewal: stillness, serenity &amp; grounded</h3>
@@ -711,6 +699,17 @@
     </div>
     <h3 class="past-events-heading">Past Events</h3>
     <div class="events-grid">
+      <div class="event-card">
+        <img src="https://github.com/user-attachments/assets/fb17b541-43be-4021-a5eb-a5f7cad04666" alt="Petals & Frequency: A Summer Solstice Retreat poster" class="event-image">
+        <div class="event-content">
+          <h3 class="event-title">Petals &amp; Frequency Collective: A Summer Solstice Retreat</h3>
+          <p class="event-location">Curated by Cosmic Connections</p>
+          <p class="event-location">An intimate full-day retreat experience blending astrology, sound healing, breathwork, meditation, yoga, acupuncture, nourishment, and intentional rest in a serene spa-like setting created to support softness, clarity, grounding, expansion, and deep restoration.</p>
+          <p class="event-host">Elysium Healing Oasis</p>
+          <p class="event-location">6634 South Kings Highway, Alexandria, VA 22306</p>
+          <p class="event-datetime">Saturday, June 13 from 10 am to 4 pm ET</p>
+        </div>
+      </div>
       <div class="event-card">
         <img src="https://github.com/user-attachments/assets/4cb76323-4bf3-424d-9305-2b740b4eac3d" alt="The Reset Retreat poster" class="event-image">
         <div class="event-content">


### PR DESCRIPTION
## Summary
- Move "Petals & Frequency Collective: A Summer Solstice Retreat" from Upcoming Events into Past Events (the June 13 date has passed)
- Drop the "Attend Event" link, consistent with other past events

Closes #29