### PR TITLE
Remove Sound Immersion for Rest & Renewal from Upcoming Events

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,16 +698,6 @@
           <a href="https://www.eventbrite.com/e/petals-frequency-a-summer-solstice-retreat-tickets-1989432374787" class="event-link" target="_blank" rel="noopener">Attend Event</a>
         </div>
       </div>
-      <div class="event-card">
-        <img src="https://images.unsplash.com/photo-1749642955698-ebe5e4579034?q=80&w=1074&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="Sound healing session" class="event-image">
-        <div class="event-content">
-          <h3 class="event-title">Sound Immersion for Rest &amp; Renewal: stillness, serenity &amp; grounded</h3>
-          <p class="event-host">Bear River Massage and Yoga</p>
-          <p class="event-location">29 Banks Ford Pkwy suite 109, Fredericksburg, VA</p>
-          <p class="event-datetime">Sunday, June 7 from 6 pm to 7 pm ET</p>
-          <a href="https://www.eventbrite.com/e/sound-immersion-for-rest-renewal-tickets-1985239563977?sg=f8fa5f5da78e9d0b97cf6a3860348a9b9db2c731570a33ef38890ac1531a57f0fe8252b1e1db9844074d3c32f75c6a881022b61561b57d2c0587a92c01a1cc82b8131c2c321ba3e2954696b466&aff=ebdsshios" class="event-link" target="_blank" rel="noopener">Attend Event</a>
-        </div>
-      </div>
     </div>
     <h3 class="past-events-heading">Past Events</h3>
     <div class="events-grid">


### PR DESCRIPTION
## Summary
- Remove the "Sound Immersion for Rest & Renewal" event card from the Upcoming Events grid (the June 7 date has passed)

Closes #30