### PR TITLE
Add Sound Bath @ Chinn Aquatics and Fitness Center event

### DIFF
--- a/index.html
+++ b/index.html
@@ -708,6 +708,19 @@
           <a href="https://www.eventbrite.com/e/sound-immersion-for-rest-renewal-tickets-1985239563977?sg=f8fa5f5da78e9d0b97cf6a3860348a9b9db2c731570a33ef38890ac1531a57f0fe8252b1e1db9844074d3c32f75c6a881022b61561b57d2c0587a92c01a1cc82b8131c2c321ba3e2954696b466&aff=ebdsshios" class="event-link" target="_blank" rel="noopener">Attend Event</a>
         </div>
       </div>
+      <div class="event-card">
+        <img src="https://github.com/user-attachments/assets/47c58922-8b02-46fd-b21d-ffefbd93c0fd" alt="Sound Bath at Chinn Aquatics and Fitness Center poster" class="event-image">
+        <div class="event-content">
+          <h3 class="event-title">Sound Bath</h3>
+          <p class="event-location">Step away from the busyness of everyday life and give yourself 55 minutes to simply be. This immersive sound bath invites you to relax, recharge, and experience the soothing sounds of crystal singing bowls and other therapeutic instruments in a peaceful, welcoming space. Allow the sounds to support deep rest, quiet reflection, and a renewed sense of balance—leaving you feeling refreshed, restored, and more in tune with yourself.</p>
+          <p class="event-location">Please bring a yoga mat, blanket, pillow, bolster, or any other items that will help you feel comfortable and supported throughout the session.</p>
+          <p class="event-host">Chinn Aquatics and Fitness Center</p>
+          <p class="event-location">13025 Chinn Park Dr, Woodbridge, VA 22192</p>
+          <p class="event-datetime">Every Monday at 7:45 pm, starting August 10, 2026</p>
+          <p class="event-location">$12 drop-in for non-members</p>
+          <a href="https://www.pwcva.gov/department/chinn-aquatics/group-fitness" class="event-link" target="_blank" rel="noopener">Attend Event</a>
+        </div>
+      </div>
     </div>
     <h3 class="past-events-heading">Past Events</h3>
     <div class="events-grid">


### PR DESCRIPTION
## Summary
- Add new Upcoming Events card for the weekly Sound Bath at Chinn Aquatics and Fitness Center (terracotta-colored host, per existing pattern)
- Recurring event: every Monday at 7:45 pm, starting August 10, 2026

Closes #32